### PR TITLE
Reopenned: enum toString() doesn't return the main value

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -32,5 +32,5 @@ enum PlaceType {
 }
 
 extension PlaceTypeX on PlaceType {
-  String get value => this.toString();
+  String get value => this.toString().split('.').last;
 }


### PR DESCRIPTION
dart enum toString() method returns the concatenated string of the Enum name and the value name. i.e. PlaceType.region.toString() will return "PlaceType.region" not "region". Ref: https://stackoverflow.com/a/29567669/7171719