### PR TITLE
external_id should be optional

### DIFF
--- a/lib/models/retrieve_response.g.dart
+++ b/lib/models/retrieve_response.g.dart
@@ -52,7 +52,7 @@ RetrieveProperties _$RetrievePropertiesFromJson(Map<String, dynamic> json) =>
       language: json['language'] as String,
       maki: json['maki'] as String,
       externalIds:
-          ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>),
+          ExternalIds.fromJson((json['external_ids'] ?? Map<String, dynamic>()) as Map<String, dynamic>),
       metadata: ExternalIds.fromJson(json['metadata'] as Map<String, dynamic>),
     );
 

--- a/lib/models/suggestion_response.g.dart
+++ b/lib/models/suggestion_response.g.dart
@@ -36,7 +36,7 @@ Suggestion _$SuggestionFromJson(Map<String, dynamic> json) => Suggestion(
       language: json['language'] as String,
       maki: json['maki'] as String?,
       externalIds:
-          ExternalIds.fromJson(json['external_ids'] as Map<String, dynamic>),
+          ExternalIds.fromJson((json['external_ids'] ?? Map<String, dynamic>()) as Map<String, dynamic>),
       poiCategory: (json['poi_category'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),


### PR DESCRIPTION
At the moment, when we are loading suggest/retrieve responses, code expects that external_id field is always present. But, for some addresses (for example "Sazonova 10") this field doesn't exist, which makes the lib crash. It should be allowed for the field to be null or an empty map (what I have changed it to).