### PR TITLE
Allow all fields on Region model to be nullable.

### DIFF
--- a/lib/models/location_context.dart
+++ b/lib/models/location_context.dart
@@ -59,9 +59,9 @@ class Region {
   });
 
   final String? id;
-  final String name;
-  final String regionCode;
-  final String regionCodeFull;
+  final String? name;
+  final String? regionCode;
+  final String? regionCodeFull;
 
   factory Region.fromJson(Map<String, dynamic> json) => _$RegionFromJson(json);
 

--- a/lib/models/location_context.g.dart
+++ b/lib/models/location_context.g.dart
@@ -56,9 +56,9 @@ Map<String, dynamic> _$CountryToJson(Country instance) => <String, dynamic>{
 
 Region _$RegionFromJson(Map<String, dynamic> json) => Region(
       id: json['id'] as String?,
-      name: json['name'] as String,
-      regionCode: json['region_code'] as String,
-      regionCodeFull: json['region_code_full'] as String,
+      name: json['name'] as String?,
+      regionCode: json['region_code'] as String?,
+      regionCodeFull: json['region_code_full'] as String?,
     );
 
 Map<String, dynamic> _$RegionToJson(Region instance) => <String, dynamic>{


### PR DESCRIPTION
The Mapbox search API can return results that have null "region_code" and other region fields, but the current JSON models require all fields to be `String` instead of `String?`. You can test this by searching for "aoeu" with the current api.getSuggestions call and seeing the JSON Parsing exception that is thrown based on the API results. This PR makes fields on the Region model nullable to avoid breaking the getSuggestions call.